### PR TITLE
Branch-coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ For more information on these inputs, see the [Workflow syntax for GitHub Action
 - `minimum-coverage`: The minimum coverage to pass the check. Optional. Default: `0` (always passes)
 - `github-token`: Set the `${{ secrets.GITHUB_TOKEN }}` token to have the action comment the coverage summary in the pull request. This token is provided by Actions, you do not need to create your own token. Optional. Default: ``
 - `working-directory`: The working directory containing the source files referenced in the LCOV files. Optional. Default: `./`
+- `branch-coverage`: Generate the branch coverage. Optional. Default: `true`
 
 ### Outputs
 None.

--- a/src/main.js
+++ b/src/main.js
@@ -62,6 +62,12 @@ async function genhtml(coverageFiles, tmpPath) {
   args.push('--output-directory');
   args.push(artifactPath);
 
+  const branchCoverage = core.getInput('branch-coverage').trim() || 'true';
+  if (branchCoverage === 'true') {
+    args.push('--rc');
+    args.push('lcov_branch_coverage=1');
+  }
+
   await exec.exec('genhtml', args, { cwd: workingDirectory });
 
   const globber = await glob.create(`${artifactPath}/**`);


### PR DESCRIPTION
Potential solution for #11 

This change adds a new option, called `branch-coverage`. It's an optional option, defaults to `true`. This option will add the `--rc lcov_branch_coverage=1` flag at genhtml.