### PR TITLE
Allow disabling generation of HTML reports

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     required: true
   artifact-name:
     description: 'The GitHub artifact name of the generated HTML report. For example, `code-coverage-report`. _Note:_ When downloading, it will be extracted in an `html` directory. Optional. Default: `` (Skips uploading of artifacts)'
+  generate-html-report:
+    description: 'Set to `false` to skip generating the HTML report entirely. Optional. Default: `true`'
+    required: false
+    default: "true"
   minimum-coverage:
     description: 'The minimum coverage to pass the check. Optional. Default: `0` (always passes)'
     default: 0

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,10 @@ async function run() {
     const additionalMessage = core.getInput('additional-message');
     const updateComment = core.getInput('update-comment') === 'true';
 
-    await genhtml(coverageFiles, tmpPath);
+    const genHtmlReport = core.getInput('generate-html-report') === 'true';
+    if (genHtmlReport) {
+      await genhtml(coverageFiles, tmpPath);
+    }
 
     const coverageFile = await mergeCoverages(coverageFiles, tmpPath);
     const totalCoverage = lcovTotal(coverageFile);


### PR DESCRIPTION
This is both because my code coverage tool already generates reports, and to work around #231 without using [a workaround like this](https://github.com/zgosalvez/github-actions-flutter-workflows/blob/main/.github/workflows/ci.yml#L78)