### PR TITLE
Bump brace-expansion and update build artifact

### DIFF
--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -36288,7 +36288,7 @@ function expand_(str, max, isTop) {
             }
             const pad = n.some(isPadded);
             N = [];
-            for (let i = x; test(i, y); i += incr) {
+            for (let i = x; test(i, y) && N.length < max; i += incr) {
                 let c;
                 if (isAlphaSequence) {
                     c = String.fromCharCode(i);
@@ -81111,9 +81111,12 @@ function requireBraceExpansion () {
 	  return parts;
 	}
 
-	function expandTop(str) {
+	function expandTop(str, options) {
 	  if (!str)
 	    return [];
+
+	  options = options || {};
+	  var max = options.max == null ? Infinity : options.max;
 
 	  // I don't know why Bash 4.3 does this, but it does.
 	  // Anything starting with {} will have the first two bytes preserved
@@ -81125,7 +81128,7 @@ function requireBraceExpansion () {
 	    str = '\\{\\}' + str.substr(2);
 	  }
 
-	  return expand(escapeBraces(str), true).map(unescapeBraces);
+	  return expand(escapeBraces(str), max, true).map(unescapeBraces);
 	}
 
 	function embrace(str) {
@@ -81142,7 +81145,7 @@ function requireBraceExpansion () {
 	  return i >= y;
 	}
 
-	function expand(str, isTop) {
+	function expand(str, max, isTop) {
 	  var expansions = [];
 
 	  var m = balanced('{', '}', str);
@@ -81151,11 +81154,11 @@ function requireBraceExpansion () {
 	  // no need to expand pre, since it is guaranteed to be free of brace-sets
 	  var pre = m.pre;
 	  var post = m.post.length
-	    ? expand(m.post, false)
+	    ? expand(m.post, max, false)
 	    : [''];
 
 	  if (/\$$/.test(m.pre)) {    
-	    for (var k = 0; k < post.length; k++) {
+	    for (var k = 0; k < post.length && k < max; k++) {
 	      var expansion = pre+ '{' + m.body + '}' + post[k];
 	      expansions.push(expansion);
 	    }
@@ -81168,7 +81171,7 @@ function requireBraceExpansion () {
 	      // {a},b}
 	      if (m.post.match(/,(?!,).*\}/)) {
 	        str = m.pre + '{' + m.body + escClose + m.post;
-	        return expand(str);
+	        return expand(str, max, true);
 	      }
 	      return [str];
 	    }
@@ -81180,7 +81183,7 @@ function requireBraceExpansion () {
 	      n = parseCommaParts(m.body);
 	      if (n.length === 1) {
 	        // x{{a,b}}y ==> x{a}y x{b}y
-	        n = expand(n[0], false).map(embrace);
+	        n = expand(n[0], max, false).map(embrace);
 	        if (n.length === 1) {
 	          return post.map(function(p) {
 	            return m.pre + n[0] + p;
@@ -81235,12 +81238,12 @@ function requireBraceExpansion () {
 	      N = [];
 
 	      for (var j = 0; j < n.length; j++) {
-	        N.push.apply(N, expand(n[j], false));
+	        N.push.apply(N, expand(n[j], max, false));
 	      }
 	    }
 
 	    for (var j = 0; j < N.length; j++) {
-	      for (var k = 0; k < post.length; k++) {
+	      for (var k = 0; k < post.length && expansions.length < max; k++) {
 	        var expansion = pre + N[j] + post[k];
 	        if (!isTop || isSequence || expansion)
 	          expansions.push(expansion);
@@ -103824,7 +103827,7 @@ function requireCommonjs$5 () {
 		            }
 		            const pad = n.some(isPadded);
 		            N = [];
-		            for (let i = x; test(i, y); i += incr) {
+		            for (let i = x; test(i, y) && N.length < max; i += incr) {
 		                let c;
 		                if (isAlphaSequence) {
 		                    c = String.fromCharCode(i);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1411,9 +1411,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2620,9 +2620,9 @@
       }
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"


### PR DESCRIPTION
Update package-lock to bump brace-expansion (top-level 5.0.5 → 5.0.6 and nested 2.0.3 → 2.1.0) with updated resolved URLs and integrity hashes. Also include an updated dist/main/index.js binary (rebuilt artifact) to pick up the dependency changes.